### PR TITLE
add non-interactive authentication

### DIFF
--- a/src/neuronx_distributed/scripts/checkpoint_converter.py
+++ b/src/neuronx_distributed/scripts/checkpoint_converter.py
@@ -76,7 +76,9 @@ class CheckpointConverterBase:
 
         from transformers import AutoModelForCausalLM
 
-        token = getpass("Enter your Hugging Face API token: (If you don't have one, create it at https://huggingface.co/settings/tokens): ")
+        token = os.getenv("HF_TOKEN", None)
+        if token is None:
+            token = getpass("Enter your Hugging Face API token: (If you don't have one, create it at https://huggingface.co/settings/tokens): ")
         login(token=token)
 
         print(f"Downloading model: {model_identifier}")


### PR DESCRIPTION
Currently use of `getpass` forces interactive Hugging Face authentication. Need the option to do non-interactive Hugging Face authentication via `HF_TOKEN` environment variable.
